### PR TITLE
Initial inclusion of TensorImpl

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -13,15 +13,20 @@ pub trait Backward<T>: Debug
 where
     T: DTypeMarker + Zero + Clone + Debug,
 {
-    fn calculate_gradient(&self, others: Vec<Arc<Tensor<T>>>) -> Vec<Arc<Tensor<T>>>;
+    /// Save received gradient to origin tensor; calculate gradient and traverse through the graph
+    fn calculate_gradient(&self, others: Arc<Vec<Tensor<T>>>) -> Arc<Vec<Tensor<T>>>;
 
+    /// Call `self.calculate_gradient` on connected Nodes through Edge(s)
     fn traverse(&self);
 
+    /// Get edge list
     fn get_edge_list(&self) -> &[Edge<T>];
 
-    fn add_to_node_list(&self);
+    /// Add edge to list, this Node will also own the edge
+    fn add_to_edge_list(&mut self, edge: Edge<T>);
 
-    fn save_input_refs(&self, input_refs: &[&Tensor<T>]);
+    /// Save references of input tensors used to compute the tensor this Node belongs to
+    fn save_input_refs(&mut self, input_refs: &[&Tensor<T>]);
 
     fn save_grad_to_origin_tensor(&self, tensor: Arc<Tensor<T>>);
 }

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
-
 use super::super::tensor_core::dtypes::DTypeMarker;
 use super::super::tensor_core::tensor::Tensor;
 use super::edge::Edge;
 
 use num_traits::Zero;
 use std::fmt::Debug;
+use std::rc::Rc;
 
 pub mod grad_accum;
 
@@ -14,7 +13,7 @@ where
     T: DTypeMarker + Zero + Clone + Debug,
 {
     /// Save received gradient to origin tensor; calculate gradient and traverse through the graph
-    fn calculate_gradient(&self, others: Arc<Vec<Tensor<T>>>) -> Arc<Vec<Tensor<T>>>;
+    fn calculate_gradient(&self, others: Rc<Vec<Tensor<T>>>) -> Rc<Vec<Tensor<T>>>;
 
     /// Call `self.calculate_gradient` on connected Nodes through Edge(s)
     fn traverse(&self);
@@ -28,5 +27,5 @@ where
     /// Save references of input tensors used to compute the tensor this Node belongs to
     fn save_input_refs(&mut self, input_refs: &[&Tensor<T>]);
 
-    fn save_grad_to_origin_tensor(&self, tensor: Arc<Tensor<T>>);
+    fn save_grad_to_origin_tensor(&self, tensor: Rc<Tensor<T>>);
 }

--- a/src/graph/node/grad_accum.rs
+++ b/src/graph/node/grad_accum.rs
@@ -23,22 +23,30 @@ impl<T> Backward<T> for GradAccum<T>
 where
     T: Zero + Clone + DTypeMarker + Debug,
 {
+    fn calculate_gradient(&self, _others: Arc<Vec<Tensor<T>>>) -> Arc<Vec<Tensor<T>>> {
+        return Arc::new(vec![]);
+    }
+
+    fn traverse(&self) {
+        todo!()
+    }
+
     fn get_edge_list(&self) -> &[Edge<T>] {
         return &self.edge_list;
     }
 
-    fn save_input_refs(&self, _input_refs: &[&Tensor<T>]) {}
-
-    fn add_to_node_list(&self) {}
-
-    fn calculate_gradient(&self, _others: Vec<Arc<Tensor<T>>>) -> Vec<Arc<Tensor<T>>> {
-        return vec![];
+    fn save_input_refs(&mut self, input_refs: &[&Tensor<T>]) {
+        for tensor_ref in 0..input_refs.len() {}
     }
 
-    fn traverse(&self) {}
-
     /// save gradient to the origin tensor
-    fn save_grad_to_origin_tensor(&self, _grad: Arc<Tensor<T>>) {}
+    fn save_grad_to_origin_tensor(&self, _grad: Arc<Tensor<T>>) {
+        todo!()
+    }
+
+    fn add_to_edge_list(&mut self, _edge: Edge<T>) {
+        todo!()
+    }
 }
 
 impl<T> GradAccum<T>

--- a/src/graph/node/grad_accum.rs
+++ b/src/graph/node/grad_accum.rs
@@ -2,12 +2,13 @@ use super::super::edge::Edge;
 use super::super::node::Backward;
 use super::DTypeMarker;
 
-use super::super::super::tensor_core::autograd_meta::AutogradMeta;
+use super::super::super::tensor_core::tensor_impl::TensorImpl;
 use super::Tensor;
 
 use num_traits::Zero;
+use std::cell::RefCell;
 use std::fmt::Debug;
-use std::sync::{Arc, Weak};
+use std::rc::{Rc, Weak};
 
 #[derive(Debug)]
 pub struct GradAccum<T>
@@ -15,16 +16,16 @@ where
     T: Zero + Clone + DTypeMarker + Debug,
 {
     edge_list: Vec<Edge<T>>,
-    origin: Option<Weak<AutogradMeta<T>>>,
-    inputs: Vec<Arc<Tensor<T>>>,
+    origin: Option<Weak<RefCell<TensorImpl<T>>>>,
+    inputs: Vec<Rc<Tensor<T>>>,
 }
 
 impl<T> Backward<T> for GradAccum<T>
 where
     T: Zero + Clone + DTypeMarker + Debug,
 {
-    fn calculate_gradient(&self, _others: Arc<Vec<Tensor<T>>>) -> Arc<Vec<Tensor<T>>> {
-        return Arc::new(vec![]);
+    fn calculate_gradient(&self, _others: Rc<Vec<Tensor<T>>>) -> Rc<Vec<Tensor<T>>> {
+        return Rc::new(vec![]);
     }
 
     fn traverse(&self) {
@@ -35,12 +36,12 @@ where
         return &self.edge_list;
     }
 
-    fn save_input_refs(&mut self, input_refs: &[&Tensor<T>]) {
-        for tensor_ref in 0..input_refs.len() {}
+    fn save_input_refs(&mut self, _input_refs: &[&Tensor<T>]) {
+        todo!()
     }
 
     /// save gradient to the origin tensor
-    fn save_grad_to_origin_tensor(&self, _grad: Arc<Tensor<T>>) {
+    fn save_grad_to_origin_tensor(&self, _grad: Rc<Tensor<T>>) {
         todo!()
     }
 
@@ -53,7 +54,7 @@ impl<T> GradAccum<T>
 where
     T: Zero + Clone + DTypeMarker + Debug,
 {
-    pub fn new(edge_list: Vec<Edge<T>>, inputs: Vec<Arc<Tensor<T>>>) -> Self {
+    pub fn new(edge_list: Vec<Edge<T>>, inputs: Vec<Rc<Tensor<T>>>) -> Self {
         let grad_accum = GradAccum {
             edge_list: edge_list,
             origin: None,
@@ -63,8 +64,24 @@ where
         return grad_accum;
     }
 
-    pub fn set_owned_meta(&mut self, origin: Arc<AutogradMeta<T>>) {
-        self.origin = Some(Arc::downgrade(&origin));
+    pub fn new_with_origin(edge_list: Vec<Edge<T>>, origin: Rc<RefCell<TensorImpl<T>>>) -> Self {
+        let grad_accum = GradAccum {
+            edge_list: edge_list,
+            origin: Some(GradAccum::convert_origin_to_weak(origin)),
+            inputs: vec![],
+        };
+
+        return grad_accum;
+    }
+
+    pub fn convert_origin_to_weak(
+        origin: Rc<RefCell<TensorImpl<T>>>,
+    ) -> Weak<RefCell<TensorImpl<T>>> {
+        return Rc::downgrade(&origin);
+    }
+
+    pub fn set_owned_meta(&mut self, origin: Rc<RefCell<TensorImpl<T>>>) {
+        self.origin = Some(Rc::downgrade(&origin));
     }
 }
 

--- a/src/tensor_core.rs
+++ b/src/tensor_core.rs
@@ -2,4 +2,6 @@ pub mod autograd_meta;
 pub mod dtypes;
 pub mod ops;
 pub mod storage;
+
 pub mod tensor;
+pub mod tensor_impl;

--- a/src/tensor_core/autograd_meta.rs
+++ b/src/tensor_core/autograd_meta.rs
@@ -1,5 +1,6 @@
 use super::dtypes::DTypeMarker;
 use super::tensor::Tensor;
+use super::tensor_impl::TensorImpl;
 
 use super::super::graph::node::Backward;
 use super::super::graph::node::grad_accum::GradAccum;
@@ -7,7 +8,7 @@ use super::super::graph::node::grad_accum::GradAccum;
 use num_traits::Zero;
 use std::cell::RefCell;
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct AutogradMeta<T>
@@ -15,10 +16,10 @@ where
     T: DTypeMarker + Zero + Clone + Debug,
 {
     pub name: String,
-    pub grad: RefCell<Option<Arc<Tensor<T>>>>,
+    pub grad: RefCell<Option<Rc<Tensor<T>>>>,
     pub requires_grad: bool,
-    pub grad_fn: Option<Arc<RefCell<dyn Backward<T>>>>,
-    pub grad_accum: Option<Arc<RefCell<GradAccum<T>>>>,
+    pub grad_fn: Option<Rc<RefCell<dyn Backward<T>>>>,
+    pub grad_accum: Option<Rc<RefCell<GradAccum<T>>>>,
 }
 
 impl<T> AutogradMeta<T>
@@ -27,7 +28,7 @@ where
 {
     pub fn new_for_intermediate(
         name: String,
-        grad_fn: Option<Arc<RefCell<dyn Backward<T>>>>,
+        grad_fn: Option<Rc<RefCell<dyn Backward<T>>>>,
     ) -> Self {
         let autograd_meta = AutogradMeta {
             name: name,
@@ -40,35 +41,32 @@ where
         return autograd_meta;
     }
 
-    pub fn new_for_leaf(name: String) -> Arc<Self> {
-        let grad_accum = Arc::new(RefCell::new(GradAccum::<T>::new(vec![], vec![])));
+    pub fn new_for_leaf(name: String, origin: Rc<RefCell<TensorImpl<T>>>) -> Self {
+        let grad_accum = Rc::new(RefCell::new(GradAccum::<T>::new_with_origin(
+            vec![],
+            origin,
+        )));
 
         let autograd_meta = AutogradMeta {
             name: name,
             grad: RefCell::new(None),
             requires_grad: true,
             grad_fn: None,
-            grad_accum: Some(Arc::clone(&grad_accum)),
+            grad_accum: Some(Rc::clone(&grad_accum)),
         };
 
-        let autograd_meta_arc = Arc::new(autograd_meta);
-
-        grad_accum
-            .borrow_mut()
-            .set_owned_meta(Arc::clone(&autograd_meta_arc));
-
-        return autograd_meta_arc;
+        return autograd_meta;
     }
 
-    pub fn set_grad_fn_to_node(&mut self, node: Arc<RefCell<dyn Backward<T>>>) {
-        self.grad_fn = Some(Arc::clone(&node));
+    pub fn set_grad_fn_to_node(&mut self, node: Rc<RefCell<dyn Backward<T>>>) {
+        self.grad_fn = Some(Rc::clone(&node));
     }
 
-    pub fn set_grad_accum_to_accum(&mut self, grad_accum_node: Arc<RefCell<GradAccum<T>>>) {
-        self.grad_accum = Some(Arc::clone(&grad_accum_node));
+    pub fn set_grad_accum_to_accum(&mut self, grad_accum_node: Rc<RefCell<GradAccum<T>>>) {
+        self.grad_accum = Some(Rc::clone(&grad_accum_node));
     }
 
-    pub fn set_grad(&self, grad: Arc<Tensor<T>>) {
+    pub fn set_grad(&self, grad: Rc<Tensor<T>>) {
         let mut tensor_grad = self.grad.borrow_mut();
         if let Some(_existing_grad) = tensor_grad.as_ref() {
             *tensor_grad = Some(grad);
@@ -77,16 +75,16 @@ where
         }
     }
 
-    pub fn get_grad_accum(&self) -> &Option<Arc<RefCell<GradAccum<T>>>> {
+    pub fn get_grad_accum(&self) -> &Option<Rc<RefCell<GradAccum<T>>>> {
         return &self.grad_accum;
     }
 
-    pub fn get_grad_fn(&self) -> &Option<Arc<RefCell<dyn Backward<T>>>> {
+    pub fn get_grad_fn(&self) -> &Option<Rc<RefCell<dyn Backward<T>>>> {
         return &self.grad_fn;
     }
 
     pub fn start_backprop_chain(&self, starting_gradient: Vec<Tensor<T>>) {
-        let starting_gradient_arc = Arc::new(starting_gradient);
+        let starting_gradient_arc = Rc::new(starting_gradient);
 
         if let Some(node_arc_ref) = self.get_grad_accum() {
             node_arc_ref

--- a/src/tensor_core/autograd_meta.rs
+++ b/src/tensor_core/autograd_meta.rs
@@ -86,13 +86,19 @@ where
     }
 
     pub fn start_backprop_chain(&self, starting_gradient: Vec<Tensor<T>>) {
+        let starting_gradient_arc = Arc::new(starting_gradient);
+
         if let Some(node_arc_ref) = self.get_grad_accum() {
-            node_arc_ref.borrow().calculate_gradient(vec![]);
+            node_arc_ref
+                .borrow()
+                .calculate_gradient(starting_gradient_arc);
             return;
         }
 
         if let Some(node_arc_ref) = self.get_grad_fn() {
-            node_arc_ref.borrow().calculate_gradient(vec![]);
+            node_arc_ref
+                .borrow()
+                .calculate_gradient(starting_gradient_arc);
         } else {
             panic!("Error, calling backwards on a non-leaf tensor with no preceeding operation");
         }

--- a/src/tensor_core/ops/add.rs
+++ b/src/tensor_core/ops/add.rs
@@ -19,7 +19,7 @@ where
         let data = self.get_raw_data();
         let new_raw_data = data + _rhs;
 
-        let tensor = Tensor::from_raw_array(new_raw_data);
+        let tensor = Tensor::from_raw_array(new_raw_data, false);
 
         return tensor;
     }
@@ -47,7 +47,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data + self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -74,7 +74,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data + self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -101,7 +101,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data + self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -128,7 +128,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data + self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -154,7 +154,7 @@ where
 
     fn add(self, rhs: &'b Tensor<TensorType>) -> Self::Output {
         let new_raw_data = self.get_raw_data() + rhs.get_raw_data();
-        Tensor::from_raw_array(new_raw_data)
+        return Tensor::from_raw_array(new_raw_data, false);
     }
 }
 

--- a/src/tensor_core/ops/add.rs
+++ b/src/tensor_core/ops/add.rs
@@ -4,7 +4,7 @@ use super::super::tensor::Tensor;
 use ndarray::ScalarOperand;
 use num_traits::Zero;
 use std::fmt::Debug;
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, Deref};
 
 // ADD FOR TENSOR AND SCALAR
 
@@ -17,7 +17,7 @@ where
 
     fn add(self, _rhs: ScalarType) -> Tensor<TensorType> {
         let data = self.get_raw_data();
-        let new_raw_data = data + _rhs;
+        let new_raw_data = data.deref() + _rhs;
 
         let tensor = Tensor::from_raw_array(new_raw_data, false);
 
@@ -45,7 +45,7 @@ where
 
     fn add(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data + self;
+        let new_data = raw_data.deref() + self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -72,7 +72,7 @@ where
 
     fn add(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data + self;
+        let new_data = raw_data.deref() + self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -99,7 +99,7 @@ where
 
     fn add(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data + self;
+        let new_data = raw_data.deref() + self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -126,7 +126,7 @@ where
 
     fn add(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data + self;
+        let new_data = raw_data.deref() + self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -153,7 +153,7 @@ where
     type Output = Tensor<TensorType>;
 
     fn add(self, rhs: &'b Tensor<TensorType>) -> Self::Output {
-        let new_raw_data = self.get_raw_data() + rhs.get_raw_data();
+        let new_raw_data = self.get_raw_data().deref() + rhs.get_raw_data().deref();
         return Tensor::from_raw_array(new_raw_data, false);
     }
 }

--- a/src/tensor_core/ops/dot.rs
+++ b/src/tensor_core/ops/dot.rs
@@ -24,7 +24,7 @@ where
 
         let raw_array = left_raw_array.dot(&right_raw_array).into_dyn();
 
-        let tensor = Tensor::from_raw_array(raw_array);
+        let tensor = Tensor::from_raw_array(raw_array, false);
 
         return tensor;
     }

--- a/src/tensor_core/ops/mul.rs
+++ b/src/tensor_core/ops/mul.rs
@@ -4,7 +4,7 @@ use super::super::tensor::Tensor;
 use ndarray::ScalarOperand;
 use num_traits::Zero;
 use std::fmt::Debug;
-use std::ops::{Mul, MulAssign};
+use std::ops::{Deref, Mul, MulAssign};
 
 impl<'a, TensorType, ScalarType> Mul<ScalarType> for &'a Tensor<TensorType>
 where
@@ -15,7 +15,7 @@ where
 
     fn mul(self, rhs: ScalarType) -> Self::Output {
         let raw_array = self.get_raw_data();
-        let new_array = raw_array * rhs;
+        let new_array = raw_array.deref() * rhs;
 
         let tensor = Tensor::from_raw_array(new_array, false);
 
@@ -43,7 +43,7 @@ where
 
     fn mul(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data * self;
+        let new_data = raw_data.deref() * self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -70,7 +70,7 @@ where
 
     fn mul(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data * self;
+        let new_data = raw_data.deref() * self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -97,7 +97,7 @@ where
 
     fn mul(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data * self;
+        let new_data = raw_data.deref() * self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -124,7 +124,7 @@ where
 
     fn mul(self, rhs: &'a Tensor<TensorType>) -> Self::Output {
         let raw_data = rhs.get_raw_data();
-        let new_data = raw_data * self;
+        let new_data = raw_data.deref() * self;
 
         let tensor = Tensor::from_raw_array(new_data, false);
 
@@ -155,7 +155,7 @@ where
         let left_raw_array = self.get_raw_data();
         let right_raw_array = rhs.get_raw_data();
 
-        let raw_array = left_raw_array * right_raw_array;
+        let raw_array = left_raw_array.deref() * right_raw_array.deref();
 
         let tensor = Tensor::from_raw_array(raw_array, false);
 

--- a/src/tensor_core/ops/mul.rs
+++ b/src/tensor_core/ops/mul.rs
@@ -17,7 +17,7 @@ where
         let raw_array = self.get_raw_data();
         let new_array = raw_array * rhs;
 
-        let tensor = Tensor::from_raw_array(new_array);
+        let tensor = Tensor::from_raw_array(new_array, false);
 
         return tensor;
     }
@@ -45,7 +45,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data * self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -72,7 +72,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data * self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -99,7 +99,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data * self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -126,7 +126,7 @@ where
         let raw_data = rhs.get_raw_data();
         let new_data = raw_data * self;
 
-        let tensor = Tensor::from_raw_array(new_data);
+        let tensor = Tensor::from_raw_array(new_data, false);
 
         return tensor;
     }
@@ -157,7 +157,7 @@ where
 
         let raw_array = left_raw_array * right_raw_array;
 
-        let tensor = Tensor::from_raw_array(raw_array);
+        let tensor = Tensor::from_raw_array(raw_array, false);
 
         return tensor;
     }

--- a/src/tensor_core/ops/subtract.rs
+++ b/src/tensor_core/ops/subtract.rs
@@ -4,7 +4,7 @@ use super::super::tensor::Tensor;
 use ndarray::ScalarOperand;
 use num_traits::Zero;
 use std::fmt::Debug;
-use std::ops::{Sub, SubAssign};
+use std::ops::{Deref, Sub, SubAssign};
 
 impl<'a, TensorType, ScalarType> Sub<ScalarType> for &'a Tensor<TensorType>
 where
@@ -15,7 +15,7 @@ where
 
     fn sub(self, rhs: ScalarType) -> Self::Output {
         let raw_data = self.get_raw_data();
-        let new_raw_data = raw_data - rhs;
+        let new_raw_data = raw_data.deref() - rhs;
 
         let tensor = Tensor::from_raw_array(new_raw_data, false);
 
@@ -45,7 +45,7 @@ where
         let raw_data_left = self.get_raw_data();
         let raw_data_right = rhs.get_raw_data();
 
-        let new_raw_data = raw_data_left - raw_data_right;
+        let new_raw_data = raw_data_left.deref() - raw_data_right.deref();
 
         let tensor = Tensor::from_raw_array(new_raw_data, false);
 

--- a/src/tensor_core/ops/subtract.rs
+++ b/src/tensor_core/ops/subtract.rs
@@ -17,7 +17,7 @@ where
         let raw_data = self.get_raw_data();
         let new_raw_data = raw_data - rhs;
 
-        let tensor = Tensor::from_raw_array(new_raw_data);
+        let tensor = Tensor::from_raw_array(new_raw_data, false);
 
         return tensor;
     }
@@ -47,7 +47,7 @@ where
 
         let new_raw_data = raw_data_left - raw_data_right;
 
-        let tensor = Tensor::from_raw_array(new_raw_data);
+        let tensor = Tensor::from_raw_array(new_raw_data, false);
 
         return tensor;
     }

--- a/src/tensor_core/tensor.rs
+++ b/src/tensor_core/tensor.rs
@@ -1,93 +1,79 @@
-use super::super::config::CONFIG;
 use super::autograd_meta::AutogradMeta;
 use super::dtypes::{DTypeMarker, DTypes};
 use super::storage::Storage;
+use super::tensor_impl::TensorImpl;
 
 use ndarray::Ix2;
-use ndarray::{Array, ArrayBase, ArrayD, IxDyn, OwnedRepr};
+use ndarray::{ArrayBase, ArrayD, IxDyn, OwnedRepr};
 use num_traits::{AsPrimitive, Zero};
+use std::cell::{Ref, RefCell};
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct Tensor<T>
 where
     T: Zero + Clone + DTypeMarker + Debug,
 {
-    storage: Storage<T>,
-    shape: Vec<usize>,
-    strides: Vec<usize>,
-    numel: usize,
-    version: u64,
-    pub autograd_meta: Option<Arc<AutogradMeta<T>>>,
+    tensor_impl: Rc<RefCell<TensorImpl<T>>>,
 }
 
 impl<T> Tensor<T>
 where
     T: DTypeMarker + Zero + Clone + Debug,
 {
+    fn __get_tensor_impl(&self) -> &Rc<RefCell<TensorImpl<T>>> {
+        return &self.tensor_impl;
+    }
+
+    fn __clone_ptr_to_tensor_impl(&self) -> Rc<RefCell<TensorImpl<T>>> {
+        return Rc::clone(self.__get_tensor_impl());
+    }
+
     pub fn new(x: Vec<T>, shape: Vec<usize>, requires_grad: bool) -> Self {
-        let numel = x.len();
-        let type_signature = T::dtype();
-        let nbytes = std::mem::size_of::<T>() * (numel as usize);
+        let tensor_impl = TensorImpl::new(x, shape);
 
-        let data = Array::from_shape_vec(shape.clone(), x);
-        let data = match data {
-            Ok(x) => x,
-            Err(e) => {
-                panic!("Tensor creation error, shape mismatched: {}", e.to_string());
-            }
-        };
-
-        let storage = Storage::new(data, nbytes, type_signature);
-
-        let mut tensor = Tensor {
-            storage: storage,
-            shape: shape,
-            strides: vec![1, numel],
-            numel: numel,
-            version: CONFIG.version,
-            autograd_meta: None,
+        let tensor = Tensor {
+            tensor_impl: TensorImpl::generate_pointer_for_tensor(tensor_impl),
         };
 
         if requires_grad {
-            let autograd_meta = AutogradMeta::<T>::new_for_leaf(String::from("leaf_grad_meta"));
+            let autograd_meta = AutogradMeta::<T>::new_for_leaf(
+                String::from("leaf_grad_meta"),
+                tensor.__clone_ptr_to_tensor_impl(),
+            );
 
             tensor.set_autograd_meta(autograd_meta);
-
-            return tensor;
-        } else {
-            return tensor;
         }
+
+        return tensor;
     }
 
     /// Turns on grad tracking for a leaf tensor. Any intermediate tensor will always be
     /// created with gradient, so this method does not apply for them.
-    pub fn requires_grad(&mut self) {
-        let autograd_meta = AutogradMeta::<T>::new_for_leaf(String::from("leaf_grad_meta"));
+    pub fn requires_grad(&self) {
+        let autograd_meta = AutogradMeta::<T>::new_for_leaf(
+            String::from("leaf_grad_meta"),
+            self.__clone_ptr_to_tensor_impl(),
+        );
 
         self.set_autograd_meta(autograd_meta);
     }
 
     pub fn from_raw_array(x: ArrayBase<OwnedRepr<T>, IxDyn>, requires_grad: bool) -> Self {
-        let shape = x.shape().to_vec();
-        let numel = x.len();
-        let type_signature = T::dtype();
-        let nbytes = std::mem::size_of::<T>() * (numel as usize);
+        let tensor_impl = TensorImpl::from_raw_array_(x);
 
-        let storage = Storage::new(x, nbytes, type_signature);
-
-        let mut tensor = Tensor {
-            storage: storage,
-            shape: shape,
-            strides: vec![1, numel],
-            numel: numel,
-            version: CONFIG.version,
-            autograd_meta: None,
+        let tensor = Tensor {
+            tensor_impl: TensorImpl::generate_pointer_for_tensor(tensor_impl),
         };
 
         if requires_grad {
-            tensor.requires_grad();
+            let autograd_meta = AutogradMeta::<T>::new_for_leaf(
+                String::from("leaf_grad_meta"),
+                tensor.__clone_ptr_to_tensor_impl(),
+            );
+
+            tensor.set_autograd_meta(autograd_meta);
         }
 
         return tensor;
@@ -96,46 +82,45 @@ where
     pub fn zeros(shape: Vec<usize>) -> Self {
         let dyn_shape = IxDyn(&shape);
         let data = ArrayD::<T>::zeros(dyn_shape);
-        let numel = data.len();
-        let type_signature = DTypes::Float32;
 
-        let nbytes = std::mem::size_of::<f32>() * (numel as usize);
-        let storage = Storage::new(data, nbytes, type_signature);
+        let tensor_impl =
+            TensorImpl::generate_pointer_for_tensor(TensorImpl::from_raw_array_(data));
 
-        let tensor = Tensor {
-            storage: storage,
-            shape: shape,
-            strides: vec![1, numel],
-            numel: numel,
-            version: CONFIG.version,
-            autograd_meta: None,
-        };
+        let tensor = Tensor { tensor_impl };
 
         return tensor;
     }
 
-    fn get_storage(&self) -> &Storage<T> {
-        return &self.storage;
+    fn get_storage(&self) -> Ref<Storage<T>> {
+        return Ref::map(self.__get_tensor_impl().borrow(), |tensor_impl| {
+            &tensor_impl.storage
+        });
     }
 
-    pub fn get_shape(&self) -> &[usize] {
-        return &(self.shape);
+    pub fn get_shape(&self) -> Ref<Vec<usize>> {
+        return Ref::map(self.__get_tensor_impl().borrow(), |tensor_impl| {
+            &(tensor_impl.shape)
+        });
     }
 
-    pub fn get_strides(&self) -> &[usize] {
-        return &(self.strides);
+    pub fn get_strides(&self) -> Ref<Vec<usize>> {
+        return Ref::map(self.__get_tensor_impl().borrow(), |tensor_impl| {
+            &(tensor_impl.strides)
+        });
     }
 
     pub fn get_numel(&self) -> usize {
-        return self.numel;
+        return self.__get_tensor_impl().borrow().numel;
     }
 
     pub fn get_version(&self) -> u64 {
-        return self.version;
+        return self.__get_tensor_impl().borrow().version;
     }
 
-    pub fn get_raw_data(&self) -> &ArrayBase<OwnedRepr<T>, IxDyn> {
-        return self.get_storage().get_data();
+    pub fn get_raw_data(&self) -> Ref<ArrayBase<OwnedRepr<T>, IxDyn>> {
+        return Ref::map(self.__get_tensor_impl().borrow(), |tensor_impl| {
+            tensor_impl.get_storage_().get_data()
+        });
     }
 
     pub fn get_raw_data_as_ix2(&self) -> ArrayBase<OwnedRepr<T>, Ix2> {
@@ -150,23 +135,20 @@ where
         return self.get_storage().get_dtype();
     }
 
-    pub fn get_autograd_ref(&self) -> &Option<Arc<AutogradMeta<T>>> {
-        return &self.autograd_meta;
+    pub fn get_autograd_ref(&self) -> Ref<Option<AutogradMeta<T>>> {
+        return Ref::map(self.__get_tensor_impl().borrow(), |tensor_impl_| {
+            &tensor_impl_.autograd_meta
+        });
     }
 
-    pub fn set_autograd_meta(&mut self, autograd_meta: Arc<AutogradMeta<T>>) {
-        self.autograd_meta = Some(autograd_meta);
+    fn set_autograd_meta(&self, autograd_meta: AutogradMeta<T>) {
+        self.__get_tensor_impl().borrow_mut().autograd_meta = Some(autograd_meta);
     }
 
     pub fn backward(&mut self, starting_gradient: Vec<Tensor<T>>) {
-        match self.get_autograd_ref() {
-            Some(autograd_meta_arc_ref) => {
-                autograd_meta_arc_ref.start_backprop_chain(starting_gradient);
-            }
-            None => {
-                panic!("Error, calling backwards on a tensor without ")
-            }
-        }
+        self.__get_tensor_impl()
+            .borrow_mut()
+            .backward_(starting_gradient);
     }
 }
 

--- a/src/tensor_core/tensor_impl.rs
+++ b/src/tensor_core/tensor_impl.rs
@@ -1,0 +1,135 @@
+use super::super::config::CONFIG;
+use super::autograd_meta::AutogradMeta;
+use super::dtypes::{DTypeMarker, DTypes};
+use super::storage::Storage;
+use super::tensor::Tensor;
+
+use ndarray::Ix2;
+use ndarray::{Array, ArrayBase, IxDyn, OwnedRepr};
+use num_traits::Zero;
+use std::fmt::Debug;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug)]
+pub struct TensorImpl<T>
+where
+    T: Zero + Clone + DTypeMarker + Debug,
+{
+    pub storage: Storage<T>,
+    pub shape: Vec<usize>,
+    pub strides: Vec<usize>,
+    pub numel: usize,
+    pub version: u64,
+    pub autograd_meta: Option<AutogradMeta<T>>,
+}
+
+impl<T> TensorImpl<T>
+where
+    T: DTypeMarker + Zero + Clone + Debug,
+{
+    pub fn new(x: Vec<T>, shape: Vec<usize>) -> Self {
+        let numel = x.len();
+        let type_signature = T::dtype();
+        let nbytes = std::mem::size_of::<T>() * (numel as usize);
+
+        let data = Array::from_shape_vec(shape.clone(), x);
+        let data = match data {
+            Ok(x) => x,
+            Err(e) => {
+                panic!("Tensor creation error, shape mismatched: {}", e.to_string());
+            }
+        };
+
+        let storage = Storage::new(data, nbytes, type_signature);
+
+        let tensor_impl = TensorImpl {
+            storage: storage,
+            shape: shape,
+            strides: vec![1, numel],
+            numel: numel,
+            version: CONFIG.version,
+            autograd_meta: None,
+        };
+
+        return tensor_impl;
+    }
+
+    pub fn generate_pointer_for_tensor(tensor_impl: Self) -> Rc<RefCell<Self>> {
+        return Rc::new(RefCell::new(tensor_impl));
+    }
+
+    /// Turns on grad tracking for a leaf tensor. Any intermediate tensor will always be
+    /// created with gradient, so this method does not apply for them.
+
+    pub fn from_raw_array_(x: ArrayBase<OwnedRepr<T>, IxDyn>) -> Self {
+        let shape = x.shape().to_vec();
+        let numel = x.len();
+        let type_signature = T::dtype();
+        let nbytes = std::mem::size_of::<T>() * (numel as usize);
+
+        let storage = Storage::new(x, nbytes, type_signature);
+
+        let tensor_impl = TensorImpl {
+            storage: storage,
+            shape: shape,
+            strides: vec![1, numel],
+            numel: numel,
+            version: CONFIG.version,
+            autograd_meta: None,
+        };
+
+        return tensor_impl;
+    }
+
+    pub fn get_storage_(&self) -> &Storage<T> {
+        return &self.storage;
+    }
+
+    pub fn get_raw_data_(&self) -> &ArrayBase<OwnedRepr<T>, IxDyn> {
+        return self.get_storage_().get_data();
+    }
+
+    pub fn get_raw_data_as_ix2_(&self) -> ArrayBase<OwnedRepr<T>, Ix2> {
+        return self.get_storage_().get_data_as_ix2();
+    }
+
+    pub fn get_nbytes_(&self) -> usize {
+        return self.get_storage_().get_nbytes();
+    }
+
+    pub fn get_type_(&self) -> DTypes {
+        return self.get_storage_().get_dtype();
+    }
+
+    pub fn get_autograd_ref_(&self) -> &Option<AutogradMeta<T>> {
+        return &self.autograd_meta;
+    }
+
+    pub fn set_autograd_meta_(&mut self, autograd_meta: AutogradMeta<T>) {
+        self.autograd_meta = Some(autograd_meta);
+    }
+
+    pub fn backward_(&mut self, starting_gradient: Vec<Tensor<T>>) {
+        match self.get_autograd_ref_() {
+            Some(autograd_meta_arc_ref) => {
+                autograd_meta_arc_ref.start_backprop_chain(starting_gradient);
+            }
+            None => {
+                panic!("Error, calling backwards on a tensor without ")
+            }
+        }
+    }
+}
+
+mod test {
+    #[allow(unused)]
+    use super::*;
+
+    #[test]
+    fn create_tensor_impl() {
+        let x = vec![1, 2, 3, 4];
+        let _a = TensorImpl::new(x, vec![4, 1]);
+    }
+}


### PR DESCRIPTION
**Old implementation requires too much lifetime management when tracking references in computation graph.**

Refractor old `Tensor` struct to now only containing a pointer to a `TensorImpl`. Old tensor operations regarding the details of the data are all moved to `TensorImpl`. Change interface in operations to also `deref()` the raw array received from tensor.